### PR TITLE
Add missing build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.6-alpine
 RUN mkdir /code
 WORKDIR /code
 
-RUN pip install black
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev \
+ && pip install --upgrade pip \
+ && pip install black \
+ && apk del .build-deps
 
 ENTRYPOINT ["black"]


### PR DESCRIPTION
regex is a dependency but it needs to be build which requires GCC and musl libc.
This also removes the dependencies afterwards in one step to save space.
pip is upgrated before installing black.